### PR TITLE
Update Android implementation to use non-singleton Capacitor config

### DIFF
--- a/android/capacitor-intercom/src/main/java/io/stewan/capacitor/intercom/IntercomPlugin.java
+++ b/android/capacitor-intercom/src/main/java/io/stewan/capacitor/intercom/IntercomPlugin.java
@@ -27,8 +27,9 @@ public class IntercomPlugin extends Plugin {
     public void load() {
         //
         // get config
-        String apiKey = Config.getString(CONFIG_KEY_PREFIX + "apiKey", "ADD_IN_CAPACITOR_CONFIG_JSON");
-        String appId = Config.getString(CONFIG_KEY_PREFIX + "appId", "ADD_IN_CAPACITOR_CONFIG_JSON");
+        Config config = new Config(getContext().getAssets(), null);
+        String apiKey = config.getString(CONFIG_KEY_PREFIX + "apiKey", "ADD_IN_CAPACITOR_CONFIG_JSON");
+        String appId = config.getString(CONFIG_KEY_PREFIX + "appId", "ADD_IN_CAPACITOR_CONFIG_JSON");
 
         //
         // init intercom sdk


### PR DESCRIPTION
In Capacitor 2.2.0 a change has been made to the Android implementation of the Config object: https://github.com/ionic-team/capacitor/blob/master/CHANGELOG.md#220-2020-06-10

This change makes this plugin compatible with the new version.